### PR TITLE
feat: scaffold base Next.js app with sample form and table

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  root: true,
+  extends: ['next/core-web-vitals', 'eslint:recommended'],
+  rules: {
+    'react/react-in-jsx-scope': 'off'
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# Architecture-react
+# Architecture React Base
+
+Minimal Next.js 14 project demonstrating a scalable foundation with feature-first structure, a sample form, and a data table.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   pnpm install
+   ```
+2. Run the development server:
+   ```bash
+   pnpm dev
+   ```
+3. Run tests:
+   ```bash
+   pnpm test
+   ```
+
+## Features
+
+- Next.js 14 App Router with TypeScript and Tailwind CSS.
+- Feature-based folder structure under `src/`.
+- Example user data table using TanStack Table.
+- Example user form with React Hook Form and Zod.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "architecture-react",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@tanstack/react-table": "8.9.3",
+    "react-hook-form": "7.46.1",
+    "@hookform/resolvers": "3.3.4",
+    "zod": "3.22.4",
+    "clsx": "2.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.5",
+    "@types/react": "18.2.37",
+    "@types/react-dom": "18.2.15",
+    "typescript": "5.3.3",
+    "tailwindcss": "3.3.6",
+    "postcss": "8.4.31",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0",
+    "vitest": "1.1.3",
+    "@testing-library/react": "14.0.0",
+    "@testing-library/jest-dom": "6.2.0"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,17 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Architecture React Base',
+  description: 'Starter project'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50 text-gray-900">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <main className="p-8 space-y-4">
+      <h1 className="text-2xl font-bold">Welcome</h1>
+      <p className="text-gray-700">This is a minimal Next.js base project.</p>
+      <div className="space-x-4">
+        <Link href="/users" className="text-blue-600 hover:underline">
+          Users Table
+        </Link>
+        <Link href="/users/new" className="text-blue-600 hover:underline">
+          New User Form
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/users/new/page.tsx
+++ b/src/app/users/new/page.tsx
@@ -1,0 +1,10 @@
+import UserForm from '@/features/users/components/user-form';
+
+export default function NewUserPage() {
+  return (
+    <main className="p-8 space-y-4">
+      <h1 className="text-2xl font-bold">New User</h1>
+      <UserForm />
+    </main>
+  );
+}

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -1,0 +1,16 @@
+import UsersTable from '@/features/users/components/users-table';
+import Link from 'next/link';
+
+export default function UsersPage() {
+  return (
+    <main className="p-8 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Users</h1>
+        <Link href="/users/new" className="text-blue-600 hover:underline">
+          Create User
+        </Link>
+      </div>
+      <UsersTable />
+    </main>
+  );
+}

--- a/src/components/ui/__tests__/button.test.tsx
+++ b/src/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import Button from '../button';
+
+test('renders button with text', () => {
+  render(<Button>Click me</Button>);
+  expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument();
+});

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,16 @@
+import { ButtonHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export default function Button({ className, ...props }: ButtonProps) {
+  return (
+    <button
+      className={clsx(
+        'inline-flex items-center justify-center rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/features/users/components/user-form.tsx
+++ b/src/features/users/components/user-form.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import Button from '@/components/ui/button';
+
+const schema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email')
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function UserForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting }
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = (data: FormData) => {
+    alert(JSON.stringify(data, null, 2));
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-sm">
+      <div>
+        <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+          Name
+        </label>
+        <input
+          id="name"
+          type="text"
+          {...register('name')}
+          className="mt-1 w-full rounded border border-gray-300 p-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+        />
+        {errors.name && <p className="mt-1 text-sm text-red-600">{errors.name.message}</p>}
+      </div>
+      <div>
+        <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+          Email
+        </label>
+        <input
+          id="email"
+          type="email"
+          {...register('email')}
+          className="mt-1 w-full rounded border border-gray-300 p-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+        />
+        {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>}
+      </div>
+      <Button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? 'Saving...' : 'Save'}
+      </Button>
+    </form>
+  );
+}

--- a/src/features/users/components/users-table.tsx
+++ b/src/features/users/components/users-table.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  useReactTable,
+  getCoreRowModel,
+  flexRender,
+  ColumnDef
+} from '@tanstack/react-table';
+
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+const data: User[] = [
+  { id: 1, name: 'Alice', email: 'alice@example.com' },
+  { id: 2, name: 'Bob', email: 'bob@example.com' },
+  { id: 3, name: 'Carol', email: 'carol@example.com' }
+];
+
+export default function UsersTable() {
+  const columns = useMemo<ColumnDef<User>[]>(
+    () => [
+      { accessorKey: 'id', header: 'ID' },
+      { accessorKey: 'name', header: 'Name' },
+      { accessorKey: 'email', header: 'Email' }
+    ],
+    []
+  );
+
+  const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200 border">
+        <thead className="bg-gray-50">
+          {table.getHeaderGroups().map(headerGroup => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map(header => (
+                <th
+                  key={header.id}
+                  className="px-4 py-2 text-left text-sm font-medium text-gray-700"
+                >
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody className="divide-y divide-gray-200 bg-white">
+          {table.getRowModel().rows.map(row => (
+            <tr key={row.id} className="hover:bg-gray-50">
+              {row.getVisibleCells().map(cell => (
+                <td key={cell.id} className="px-4 py-2 text-sm text-gray-900">
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- initialize Next.js 14 project with Tailwind and feature-first structure
- add sample user form with React Hook Form and Zod
- add example users data table using TanStack Table

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896185bd15c8320b81415a04565c977